### PR TITLE
Refactor recorder architecture for UI-agnostic lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # gmidi
 
-GMIDI is a Java 21 command line toolkit for experimenting with MIDI-driven piano visualizers. This initial iteration sets up the Gradle build and ships with a console-based recorder that captures input from any connected MIDI controller and writes a Standard MIDI File (`.mid`).
+GMIDI is a Java 21 toolkit for capturing MIDI performances that will evolve into a visual piano experience. The first milestone is a console recorder that writes Standard MIDI Files (`.mid`). This iteration focuses on readability and scalability so the same core logic can power future graphical interfaces.
+
+## Architecture at a glance
+
+- **Core MIDI services (`com.gmidi.midi`, `com.gmidi.recorder`)** – Pure Java classes that discover devices, manage recording sessions, and expose UI-agnostic hooks.
+- **Console front-end (`com.gmidi.cli`)** – A thin command line layer that formats prompts, resolves output paths, and delegates the actual recording to the core services.
+- **Interaction abstraction** – `RecordingInteraction` defines the lifecycle callbacks the UI must provide. The CLI supplies `ConsoleRecordingInteraction` today; a GUI can plug in its own implementation later without touching the MIDI pipeline.
 
 ## Prerequisites
+
 - Java 21 or newer
 - Gradle 8.6+ (only required the first time to regenerate the wrapper JAR)
 
 ## Bootstrapping the Gradle wrapper
+
 Binary assets such as `gradle-wrapper.jar` cannot be committed in this repository. Before using `./gradlew`, generate the wrapper JAR locally:
 
 ```bash
@@ -15,14 +23,15 @@ gradle wrapper
 
 This downloads the wrapper artifacts into `gradle/wrapper/` so subsequent invocations of `./gradlew` work as expected.
 
-## Running the recorder
-Use the Gradle wrapper to launch the CLI once the wrapper files have been bootstrapped:
+## Running the console recorder
+
+Once the wrapper files exist, launch the CLI with:
 
 ```bash
 ./gradlew :app:run
 ```
 
-The program will list all available MIDI input devices, prompt you to choose one, and guide you through starting and stopping a recording. By default, recordings are written to a timestamped file such as `recording-20241231-235945.mid` in the current directory.
+The program lists available MIDI input devices, helps you pick one, and records until you press Enter again. Recordings default to timestamped filenames such as `recording-20241231-235945.mid` in the current directory.
 
 If Gradle downloads are blocked entirely, you can run the application directly with the JDK:
 
@@ -32,10 +41,17 @@ java -cp build/classes com.gmidi.App
 ```
 
 ## Testing
-Unit tests focus on deterministic utilities that do not require MIDI hardware. Execute them with:
+
+Most tests focus on deterministic utilities that do not require MIDI hardware. Execute them with:
 
 ```bash
 ./gradlew test
 ```
 
 If Gradle cannot download dependencies in your environment, run `gradle test` with a locally installed Gradle distribution after regenerating the wrapper.
+
+## Roadmap
+
+- Introduce a desktop-friendly interface that visualizes pressed keys while delegating recording to the shared services.
+- Expand `RecordingInteraction` implementations to support richer UX (count-in, metronome, visual cues).
+- Add persistence for session metadata to feed future playback and visualization features.

--- a/app/src/main/java/com/gmidi/cli/interaction/ConsoleRecordingInteraction.java
+++ b/app/src/main/java/com/gmidi/cli/interaction/ConsoleRecordingInteraction.java
@@ -1,0 +1,48 @@
+package com.gmidi.cli.interaction;
+
+import com.gmidi.recorder.RecordingInteraction;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Scanner;
+
+/**
+ * Console implementation of {@link RecordingInteraction} used by the CLI.
+ */
+public final class ConsoleRecordingInteraction implements RecordingInteraction {
+
+    private final PrintStream out;
+    private final Scanner scanner;
+
+    public ConsoleRecordingInteraction(PrintStream out, Scanner scanner) {
+        this.out = Objects.requireNonNull(out, "out");
+        this.scanner = Objects.requireNonNull(scanner, "scanner");
+    }
+
+    @Override
+    public void onReadyToRecord() {
+        out.println();
+        out.println("Press Enter when you are ready to start recording.");
+    }
+
+    @Override
+    public void awaitStart() {
+        scanner.nextLine();
+    }
+
+    @Override
+    public void onRecordingStarted() {
+        out.println("Recording... Press Enter to stop.");
+    }
+
+    @Override
+    public void awaitStop() {
+        scanner.nextLine();
+    }
+
+    @Override
+    public void onRecordingFinished(Path outputPath) {
+        out.printf(Locale.ROOT, "Saved recording to %s%n", outputPath);
+    }
+}

--- a/app/src/main/java/com/gmidi/recorder/RecordingInteraction.java
+++ b/app/src/main/java/com/gmidi/recorder/RecordingInteraction.java
@@ -1,0 +1,29 @@
+package com.gmidi.recorder;
+
+import java.nio.file.Path;
+
+/**
+ * Abstraction for UI layers that guide the user through the recording lifecycle.
+ *
+ * <p>The callbacks are invoked by {@link com.gmidi.midi.MidiRecordingSession}
+ * as the underlying MIDI session progresses. CLI and graphical front-ends can
+ * provide implementations that display prompts, update widgets, or block until
+ * user actions occur.</p>
+ */
+public interface RecordingInteraction {
+
+    /** Called when the session is armed and waiting for the user to start. */
+    void onReadyToRecord();
+
+    /** Blocks until the user indicates recording should begin. */
+    void awaitStart();
+
+    /** Called right after the sequencer starts recording. */
+    void onRecordingStarted();
+
+    /** Blocks until the user indicates recording should stop. */
+    void awaitStop();
+
+    /** Called once the recording has been persisted to disk. */
+    void onRecordingFinished(Path outputPath);
+}


### PR DESCRIPTION
## Summary
- extract a RecordingInteraction abstraction so UI layers can guide the MIDI session lifecycle
- move console-specific prompts into a dedicated interaction class and streamline the CLI workflow
- expand the README with architectural guidance and roadmap items geared toward a future GUI

## Testing
- ./gradlew test *(fails: missing gradle-wrapper.jar in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d817b624f4832688b74b282aa7639c