### PR TITLE
Harden JavaFX UI lifecycle and modular runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # gmidi
 
-GMIDI is a Java 21 command line toolkit for experimenting with MIDI-driven piano visualizers. This initial iteration sets up the Gradle build and ships with a console-based recorder that captures input from any connected MIDI controller and writes a Standard MIDI File (`.mid`).
+GMIDI is a Java 21 toolkit for capturing MIDI performances that will evolve into a visual piano experience. The first milestone is a console recorder that writes Standard MIDI Files (`.mid`). This iteration focuses on readability and scalability so the same core logic can power future graphical interfaces.
+
+## Architecture at a glance
+
+- **Core MIDI services (`com.gmidi.midi`, `com.gmidi.recorder`)** – Pure Java classes that discover devices, manage recording sessions, and expose UI-agnostic hooks.
+- **Console front-end (`com.gmidi.cli`)** – A thin command line layer that formats prompts, resolves output paths, and delegates the actual recording to the core services.
+- **Desktop front-end (`com.gmidi.ui`)** – A JavaFX scene graph that lists MIDI inputs, renders an 88-key piano, and mirrors incoming notes while the shared session persists the MIDI file.
+- **Interaction abstraction** – `RecordingInteraction` defines the lifecycle callbacks and (optionally) receiver decoration that a UI must provide so the core session can remain oblivious to presentation concerns.
 
 ## Prerequisites
+
 - Java 21 or newer
 - Gradle 8.6+ (only required the first time to regenerate the wrapper JAR)
+- The build pulls JavaFX modules via the OpenJFX Gradle plugin when you run `./gradlew`
 
 ## Bootstrapping the Gradle wrapper
+
 Binary assets such as `gradle-wrapper.jar` cannot be committed in this repository. Before using `./gradlew`, generate the wrapper JAR locally:
 
 ```bash
@@ -15,27 +25,66 @@ gradle wrapper
 
 This downloads the wrapper artifacts into `gradle/wrapper/` so subsequent invocations of `./gradlew` work as expected.
 
-## Running the recorder
-Use the Gradle wrapper to launch the CLI once the wrapper files have been bootstrapped:
+## Running the console recorder
+
+Once the wrapper files exist, launch the CLI with:
 
 ```bash
 ./gradlew :app:run
 ```
 
-The program will list all available MIDI input devices, prompt you to choose one, and guide you through starting and stopping a recording. By default, recordings are written to a timestamped file such as `recording-20241231-235945.mid` in the current directory.
+The program lists available MIDI input devices, helps you pick one, and records until you press Enter again. Recordings default to timestamped filenames such as `recording-20241231-235945.mid` in the current directory.
 
-If Gradle downloads are blocked entirely, you can run the application directly with the JDK:
+If Gradle downloads are blocked entirely, you can run the application directly with the JDK.
+Because the project is modular and depends on JavaFX, point both compilation and execution at
+the JavaFX SDK that ships with OpenJFX (the Gradle build downloads it into your user cache on
+first use):
 
 ```bash
-javac -d build/classes $(find app/src/main/java -name "*.java")
-java -cp build/classes com.gmidi.App
+PATH_TO_FX="$HOME/.gradle/caches/modules-2/files-2.1/org.openjfx" # adjust for your platform
+javac --module-path "$PATH_TO_FX" -d build/classes $(find app/src/main/java -name "*.java")
+java --module-path "build/classes:$PATH_TO_FX" --add-modules javafx.controls,javafx.graphics \
+  --enable-native-access=ALL-UNNAMED com.gmidi/com.gmidi.App
 ```
 
+## Launching the graphical recorder
+
+The JavaFX interface shows a scrolling keyboard and flashes keys as you play. Run it with the `--gui` switch:
+
+```bash
+./gradlew :app:run --args="--gui"
+```
+
+or directly via the JDK (again pointing at the JavaFX SDK and enabling native access):
+
+```bash
+PATH_TO_FX="$HOME/.gradle/caches/modules-2/files-2.1/org.openjfx"
+javac --module-path "$PATH_TO_FX" -d build/classes $(find app/src/main/java -name "*.java")
+java --module-path "build/classes:$PATH_TO_FX" --add-modules javafx.controls,javafx.graphics \
+  --enable-native-access=ALL-UNNAMED com.gmidi/com.gmidi.App --gui
+```
+
+The Gradle tasks already pass `--enable-native-access=ALL-UNNAMED`, so the JavaFX runtime avoids
+the `sun.misc.Unsafe` warnings seen on newer JDKs.
+
+From the window you can:
+
+- Refresh and choose any available MIDI input device.
+- Pick a target `.mid` file via the platform file chooser (defaults to the timestamped suggestion).
+- Watch highlighted keys mirror the notes captured during the session.
+
 ## Testing
-Unit tests focus on deterministic utilities that do not require MIDI hardware. Execute them with:
+
+Most tests focus on deterministic utilities that do not require MIDI hardware. Execute them with:
 
 ```bash
 ./gradlew test
 ```
 
 If Gradle cannot download dependencies in your environment, run `gradle test` with a locally installed Gradle distribution after regenerating the wrapper.
+
+## Roadmap
+
+- Add richer transport controls (metronome, configurable count-in, punch in/out) on top of the existing interaction contract.
+- Provide velocity-aware colouring and sustain-pedal overlays on the keyboard visualiser.
+- Record and surface session metadata to feed future playback and visualization features.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.14'
 }
 
 repositories {
@@ -11,6 +12,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+javafx {
+    version = '21.0.2'
+    modules = ['javafx.controls']
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
@@ -18,7 +24,9 @@ java {
 }
 
 application {
+    mainModule = 'com.gmidi'
     mainClass = 'com.gmidi.App'
+    applicationDefaultJvmArgs = ['--enable-native-access=ALL-UNNAMED']
 }
 
 tasks.named('test') {

--- a/app/src/main/java/com/gmidi/App.java
+++ b/app/src/main/java/com/gmidi/App.java
@@ -1,6 +1,7 @@
 package com.gmidi;
 
 import com.gmidi.cli.MidiRecorderCli;
+import com.gmidi.ui.MidiRecorderApp;
 import java.io.InputStream;
 import java.io.PrintStream;
 
@@ -14,6 +15,11 @@ public final class App {
     }
 
     public static void main(String[] args) {
+        if (args.length > 0 && "--gui".equalsIgnoreCase(args[0])) {
+            MidiRecorderApp.launchApp();
+            return;
+        }
+
         int exitCode = run(System.in, System.out);
         if (exitCode != 0) {
             System.exit(exitCode);

--- a/app/src/main/java/com/gmidi/cli/interaction/ConsoleRecordingInteraction.java
+++ b/app/src/main/java/com/gmidi/cli/interaction/ConsoleRecordingInteraction.java
@@ -1,0 +1,48 @@
+package com.gmidi.cli.interaction;
+
+import com.gmidi.recorder.RecordingInteraction;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Scanner;
+
+/**
+ * Console implementation of {@link RecordingInteraction} used by the CLI.
+ */
+public final class ConsoleRecordingInteraction implements RecordingInteraction {
+
+    private final PrintStream out;
+    private final Scanner scanner;
+
+    public ConsoleRecordingInteraction(PrintStream out, Scanner scanner) {
+        this.out = Objects.requireNonNull(out, "out");
+        this.scanner = Objects.requireNonNull(scanner, "scanner");
+    }
+
+    @Override
+    public void onReadyToRecord() {
+        out.println();
+        out.println("Press Enter when you are ready to start recording.");
+    }
+
+    @Override
+    public void awaitStart() {
+        scanner.nextLine();
+    }
+
+    @Override
+    public void onRecordingStarted() {
+        out.println("Recording... Press Enter to stop.");
+    }
+
+    @Override
+    public void awaitStop() {
+        scanner.nextLine();
+    }
+
+    @Override
+    public void onRecordingFinished(Path outputPath) {
+        out.printf(Locale.ROOT, "Saved recording to %s%n", outputPath);
+    }
+}

--- a/app/src/main/java/com/gmidi/midi/MidiRecordingSession.java
+++ b/app/src/main/java/com/gmidi/midi/MidiRecordingSession.java
@@ -1,11 +1,18 @@
 package com.gmidi.midi;
 
+import com.gmidi.recorder.RecordingInteraction;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Scanner;
-import javax.sound.midi.*;
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.Sequence;
+import javax.sound.midi.Sequencer;
+import javax.sound.midi.Track;
+import javax.sound.midi.Transmitter;
 
 /**
  * Handles recording events from a MIDI device into a Standard MIDI File.
@@ -14,17 +21,13 @@ public final class MidiRecordingSession {
 
     private static final int DEFAULT_RESOLUTION = 480;
 
-    private final PrintStream out;
-
-    public MidiRecordingSession(PrintStream out) {
-        this.out = Objects.requireNonNull(out, "out");
-    }
-
-    public void record(MidiDevice.Info deviceInfo, Path outputPath, Scanner scanner)
-            throws MidiUnavailableException, IOException {
+    public void record(
+            MidiDevice.Info deviceInfo,
+            Path outputPath,
+            RecordingInteraction interaction) throws MidiUnavailableException, IOException {
         Objects.requireNonNull(deviceInfo, "deviceInfo");
         Objects.requireNonNull(outputPath, "outputPath");
-        Objects.requireNonNull(scanner, "scanner");
+        Objects.requireNonNull(interaction, "interaction");
 
         try (MidiDevice device = MidiSystem.getMidiDevice(deviceInfo);
              Sequencer sequencer = MidiSystem.getSequencer(false)) {
@@ -37,16 +40,15 @@ public final class MidiRecordingSession {
             sequencer.recordEnable(track, -1);
 
             try (Transmitter transmitter = device.getTransmitter();
-                 Receiver receiver = sequencer.getReceiver()) {
+                 Receiver receiver = interaction.decorateReceiver(sequencer.getReceiver())) {
                 transmitter.setReceiver(receiver);
 
-                out.println();
-                out.println("Press Enter when you are ready to start recording.");
-                scanner.nextLine();
+                interaction.onReadyToRecord();
+                interaction.awaitStart();
 
                 sequencer.startRecording();
-                out.println("Recording... Press Enter to stop.");
-                scanner.nextLine();
+                interaction.onRecordingStarted();
+                interaction.awaitStop();
             }
 
             if (sequencer.isRecording()) {
@@ -56,7 +58,7 @@ public final class MidiRecordingSession {
             sequencer.recordDisable(track);
 
             MidiSystem.write(sequence, 1, outputPath.toFile());
-            out.printf("Saved recording to %s%n", outputPath);
+            interaction.onRecordingFinished(outputPath);
         } catch (InvalidMidiDataException e) {
             throw new RuntimeException(e);
         }

--- a/app/src/main/java/com/gmidi/recorder/RecordingInteraction.java
+++ b/app/src/main/java/com/gmidi/recorder/RecordingInteraction.java
@@ -1,0 +1,38 @@
+package com.gmidi.recorder;
+
+import java.nio.file.Path;
+
+/**
+ * Abstraction for UI layers that guide the user through the recording lifecycle.
+ *
+ * <p>The callbacks are invoked by {@link com.gmidi.midi.MidiRecordingSession}
+ * as the underlying MIDI session progresses. CLI and graphical front-ends can
+ * provide implementations that display prompts, update widgets, or block until
+ * user actions occur.</p>
+ */
+public interface RecordingInteraction {
+
+    /** Called when the session is armed and waiting for the user to start. */
+    void onReadyToRecord();
+
+    /** Blocks until the user indicates recording should begin. */
+    void awaitStart();
+
+    /** Called right after the sequencer starts recording. */
+    void onRecordingStarted();
+
+    /** Blocks until the user indicates recording should stop. */
+    void awaitStop();
+
+    /** Called once the recording has been persisted to disk. */
+    void onRecordingFinished(Path outputPath);
+
+    /**
+     * Allows UI layers to wrap the MIDI receiver so they can observe incoming
+     * events (for example to visualize pressed keys). Implementations that do
+     * not need to intercept events can simply rely on the default behaviour.
+     */
+    default javax.sound.midi.Receiver decorateReceiver(javax.sound.midi.Receiver downstream) {
+        return downstream;
+    }
+}

--- a/app/src/main/java/com/gmidi/ui/MidiRecorderApp.java
+++ b/app/src/main/java/com/gmidi/ui/MidiRecorderApp.java
@@ -1,0 +1,388 @@
+package com.gmidi.ui;
+
+import com.gmidi.midi.MidiDeviceUtils;
+import com.gmidi.midi.MidiRecordingSession;
+import com.gmidi.midi.RecordingFileNamer;
+import com.gmidi.recorder.RecordingInteraction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.ShortMessage;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Separator;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+
+/**
+ * JavaFX application that visualises a piano keyboard and records from MIDI devices.
+ */
+public final class MidiRecorderApp extends Application {
+
+    private final ObservableList<MidiDevice.Info> availableDevices = FXCollections.observableArrayList();
+
+    private ComboBox<MidiDevice.Info> deviceSelector;
+    private Button recordButton;
+    private Button stopButton;
+    private Label statusLabel;
+    private PianoKeyboardView keyboardView;
+    private Stage primaryStage;
+
+    private ExecutorService executor;
+    private final MidiRecordingSession recordingSession = new MidiRecordingSession();
+    private volatile FxRecordingInteraction currentInteraction;
+
+    public static void launchApp() {
+        launch(MidiRecorderApp.class);
+    }
+
+    @Override
+    public void init() {
+        executor = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r, "gmidi-recording");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @Override
+    public void start(Stage stage) {
+        primaryStage = stage;
+        stage.setTitle("GMIDI Recorder");
+        stage.setScene(new Scene(buildRoot(), 960, 360));
+        stage.show();
+        refreshDevices();
+    }
+
+    @Override
+    public void stop() {
+        FxRecordingInteraction interaction = currentInteraction;
+        if (interaction != null) {
+            interaction.requestStop();
+        }
+        executor.shutdownNow();
+        try {
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private BorderPane buildRoot() {
+        BorderPane root = new BorderPane();
+        root.setPadding(new Insets(16));
+        root.setTop(buildDeviceBar());
+        root.setCenter(buildKeyboardPane());
+        root.setBottom(buildControls());
+        return root;
+    }
+
+    private VBox buildDeviceBar() {
+        Label label = new Label("MIDI input:");
+        deviceSelector = new ComboBox<>(availableDevices);
+        deviceSelector.setPrefWidth(320);
+        deviceSelector.getSelectionModel().selectedItemProperty().addListener((obs, oldValue, newValue) -> {
+            if (currentInteraction == null) {
+                restoreIdleControls();
+            }
+        });
+        Button refreshButton = new Button("Refresh devices");
+        refreshButton.setOnAction(event -> refreshDevices());
+
+        HBox row = new HBox(12, label, deviceSelector, refreshButton);
+        row.setPadding(new Insets(0, 0, 12, 0));
+
+        VBox container = new VBox(row, new Separator());
+        container.setSpacing(12);
+        return container;
+    }
+
+    private ScrollPane buildKeyboardPane() {
+        keyboardView = new PianoKeyboardView();
+        ScrollPane scrollPane = new ScrollPane(keyboardView);
+        scrollPane.setFitToHeight(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setPadding(new Insets(12, 0, 12, 0));
+        return scrollPane;
+    }
+
+    private VBox buildControls() {
+        recordButton = new Button("Record");
+        recordButton.setOnAction(event -> startRecording());
+        stopButton = new Button("Stop");
+        stopButton.setDisable(true);
+        stopButton.setOnAction(event -> stopRecording());
+
+        HBox buttons = new HBox(12, recordButton, stopButton);
+
+        statusLabel = new Label("Select a MIDI input and press Record.");
+        statusLabel.setWrapText(true);
+        statusLabel.setMaxWidth(Double.MAX_VALUE);
+
+        Region spacer = new Region();
+        HBox statusRow = new HBox(12, buttons, spacer, statusLabel);
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        statusRow.setPadding(new Insets(12, 0, 0, 0));
+
+        VBox container = new VBox(new Separator(), statusRow);
+        container.setSpacing(12);
+        return container;
+    }
+
+    private void refreshDevices() {
+        List<MidiDevice.Info> devices = MidiDeviceUtils.listInputDevices();
+        availableDevices.setAll(devices);
+        if (devices.isEmpty()) {
+            deviceSelector.getSelectionModel().clearSelection();
+            statusLabel.setText("No MIDI input devices found.");
+        } else {
+            deviceSelector.getSelectionModel().selectFirst();
+            statusLabel.setText("Select a MIDI input and press Record.");
+        }
+        if (currentInteraction == null) {
+            restoreIdleControls();
+        }
+    }
+
+    private void startRecording() {
+        MidiDevice.Info deviceInfo = deviceSelector.getSelectionModel().getSelectedItem();
+        if (deviceInfo == null) {
+            showAlert(Alert.AlertType.WARNING, "No MIDI input", "Choose a MIDI input before recording.");
+            return;
+        }
+
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Save MIDI recording");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("MIDI files", "*.mid", "*.midi"));
+        chooser.setInitialFileName(RecordingFileNamer.defaultFileName());
+        java.io.File file = chooser.showSaveDialog(primaryStage);
+        if (file == null) {
+            statusLabel.setText("Recording cancelled.");
+            restoreIdleControls();
+            return;
+        }
+
+        Path outputPath = file.toPath();
+        recordButton.setDisable(true);
+        stopButton.setDisable(true);
+        deviceSelector.setDisable(true);
+        statusLabel.setText("Preparing to record…");
+        keyboardView.clearPressedNotes();
+
+        FxRecordingInteraction interaction = new FxRecordingInteraction(
+                recordButton, stopButton, statusLabel, keyboardView, primaryStage);
+        currentInteraction = interaction;
+
+        executor.submit(() -> runRecording(deviceInfo, outputPath, interaction));
+    }
+
+    private void runRecording(MidiDevice.Info deviceInfo, Path outputPath, FxRecordingInteraction interaction) {
+        try {
+            recordingSession.record(deviceInfo, outputPath, interaction);
+        } catch (MidiUnavailableException ex) {
+            handleFailure("Failed to open MIDI device", ex);
+        } catch (IOException ex) {
+            handleFailure("Unable to write MIDI file", ex);
+        } catch (RuntimeException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof InvalidMidiDataException) {
+                handleFailure("Encountered invalid MIDI data", ex);
+            } else {
+                handleFailure("Unexpected error during recording", ex);
+            }
+        } finally {
+            currentInteraction = null;
+            Platform.runLater(this::restoreIdleControls);
+        }
+    }
+
+    private void handleFailure(String message, Exception ex) {
+        Platform.runLater(() -> {
+            statusLabel.setText(String.format(Locale.ROOT, "%s: %s", message, ex.getMessage()));
+            restoreIdleControls();
+            showAlert(Alert.AlertType.ERROR, "Recording error",
+                    String.format(Locale.ROOT, "%s.%n%s", message, ex.getMessage()));
+        });
+    }
+
+    private void stopRecording() {
+        FxRecordingInteraction interaction = currentInteraction;
+        if (interaction != null) {
+            stopButton.setDisable(true);
+            statusLabel.setText("Stopping…");
+            interaction.requestStop();
+        }
+    }
+
+    private void showAlert(Alert.AlertType type, String title, String content) {
+        Alert alert = new Alert(type);
+        if (primaryStage != null && primaryStage.isShowing()) {
+            alert.initOwner(primaryStage);
+        }
+        alert.setTitle(title);
+        alert.setHeaderText(null);
+        alert.setContentText(content);
+        alert.showAndWait();
+    }
+
+    private void restoreIdleControls() {
+        if (recordButton == null || stopButton == null) {
+            return;
+        }
+        boolean hasDevice = deviceSelector != null
+                && deviceSelector.getSelectionModel().getSelectedItem() != null;
+        recordButton.setDisable(!hasDevice);
+        stopButton.setDisable(true);
+        if (deviceSelector != null) {
+            deviceSelector.setDisable(false);
+        }
+        if (keyboardView != null) {
+            keyboardView.clearPressedNotes();
+        }
+    }
+
+    private static final class FxRecordingInteraction implements RecordingInteraction {
+
+        private final Button recordButton;
+        private final Button stopButton;
+        private final Label statusLabel;
+        private final PianoKeyboardView keyboardView;
+        private final Stage owner;
+        private final CountDownLatch startLatch = new CountDownLatch(1);
+        private final CountDownLatch stopLatch = new CountDownLatch(1);
+
+        FxRecordingInteraction(Button recordButton,
+                               Button stopButton,
+                               Label statusLabel,
+                               PianoKeyboardView keyboardView,
+                               Stage owner) {
+            this.recordButton = Objects.requireNonNull(recordButton, "recordButton");
+            this.stopButton = Objects.requireNonNull(stopButton, "stopButton");
+            this.statusLabel = Objects.requireNonNull(statusLabel, "statusLabel");
+            this.keyboardView = Objects.requireNonNull(keyboardView, "keyboardView");
+            this.owner = Objects.requireNonNull(owner, "owner");
+        }
+
+        void requestStop() {
+            stopLatch.countDown();
+        }
+
+        @Override
+        public void onReadyToRecord() {
+            Platform.runLater(() -> {
+                statusLabel.setText("Ready. Play when you are ready – recording starts immediately.");
+                stopButton.setDisable(false);
+            });
+            startLatch.countDown();
+        }
+
+        @Override
+        public void awaitStart() {
+            try {
+                startLatch.await();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void onRecordingStarted() {
+            Platform.runLater(() -> statusLabel.setText("Recording… Press Stop when finished."));
+        }
+
+        @Override
+        public void awaitStop() {
+            try {
+                stopLatch.await();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void onRecordingFinished(Path outputPath) {
+            Platform.runLater(() -> {
+                statusLabel.setText(String.format(Locale.ROOT,
+                        "Saved recording to %s", outputPath.toAbsolutePath()));
+                recordButton.setDisable(false);
+                stopButton.setDisable(true);
+                keyboardView.clearPressedNotes();
+                Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                if (owner.isShowing()) {
+                    alert.initOwner(owner);
+                }
+                alert.setTitle("Recording complete");
+                alert.setHeaderText(null);
+                alert.setContentText(String.format(Locale.ROOT,
+                        "Recording saved to:%n%s", outputPath.toAbsolutePath()));
+                if (owner.isShowing()) {
+                    alert.showAndWait();
+                } else {
+                    alert.show();
+                }
+            });
+        }
+
+        @Override
+        public Receiver decorateReceiver(Receiver downstream) {
+            return new PianoAwareReceiver(downstream, keyboardView);
+        }
+    }
+
+    private static final class PianoAwareReceiver implements Receiver {
+
+        private final Receiver delegate;
+        private final PianoKeyboardView keyboardView;
+
+        private PianoAwareReceiver(Receiver delegate, PianoKeyboardView keyboardView) {
+            this.delegate = delegate;
+            this.keyboardView = keyboardView;
+        }
+
+        @Override
+        public void send(javax.sound.midi.MidiMessage message, long timeStamp) {
+            delegate.send(message, timeStamp);
+            if (message instanceof ShortMessage shortMessage) {
+                int command = shortMessage.getCommand();
+                int note = shortMessage.getData1();
+                int velocity = shortMessage.getData2();
+                if (command == ShortMessage.NOTE_ON && velocity > 0) {
+                    keyboardView.noteOn(note);
+                } else if (command == ShortMessage.NOTE_OFF ||
+                        (command == ShortMessage.NOTE_ON && velocity == 0)) {
+                    keyboardView.noteOff(note);
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+}

--- a/app/src/main/java/com/gmidi/ui/PianoKeyboardView.java
+++ b/app/src/main/java/com/gmidi/ui/PianoKeyboardView.java
@@ -1,0 +1,159 @@
+package com.gmidi.ui;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javafx.application.Platform;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+/**
+ * JavaFX component that renders a full 88-key piano keyboard and highlights
+ * pressed keys.
+ */
+final class PianoKeyboardView extends Pane {
+
+    private static final int FIRST_NOTE = 21; // A0
+    private static final int LAST_NOTE = 108; // C8
+    private static final double WHITE_KEY_WIDTH = 22;
+    private static final double WHITE_KEY_HEIGHT = 120;
+    private static final double BLACK_KEY_WIDTH = 14;
+    private static final double BLACK_KEY_HEIGHT = 80;
+
+    private static final Color WHITE_KEY_COLOR = Color.WHITE;
+    private static final Color WHITE_KEY_PRESSED_COLOR = Color.rgb(173, 216, 230);
+    private static final Color BLACK_KEY_COLOR = Color.BLACK;
+    private static final Color BLACK_KEY_PRESSED_COLOR = Color.rgb(30, 144, 255);
+
+    private final Map<Integer, Key> keysByNote = new HashMap<>();
+    private final List<Key> whiteKeys = new ArrayList<>();
+    private final List<Key> blackKeys = new ArrayList<>();
+    private final Set<Integer> pressedNotes = new HashSet<>();
+
+    PianoKeyboardView() {
+        buildKeys();
+        layoutKeys();
+        double totalWidth = whiteKeys.size() * WHITE_KEY_WIDTH;
+        setPrefSize(totalWidth, WHITE_KEY_HEIGHT);
+        setMinSize(totalWidth, WHITE_KEY_HEIGHT);
+        setMaxSize(totalWidth, WHITE_KEY_HEIGHT);
+    }
+
+    void noteOn(int note) {
+        if (!isPlayable(note)) {
+            return;
+        }
+        runOnFxThread(() -> {
+            pressedNotes.add(note);
+            updateKeyFill(note);
+        });
+    }
+
+    void noteOff(int note) {
+        if (!isPlayable(note)) {
+            return;
+        }
+        runOnFxThread(() -> {
+            pressedNotes.remove(note);
+            updateKeyFill(note);
+        });
+    }
+
+    void clearPressedNotes() {
+        runOnFxThread(() -> {
+            pressedNotes.clear();
+            keysByNote.values().forEach(key -> key.applyFill(false));
+        });
+    }
+
+    private void runOnFxThread(Runnable task) {
+        if (Platform.isFxApplicationThread()) {
+            task.run();
+        } else {
+            Platform.runLater(task);
+        }
+    }
+
+    private boolean isPlayable(int note) {
+        return note >= FIRST_NOTE && note <= LAST_NOTE;
+    }
+
+    private void updateKeyFill(int note) {
+        Key key = keysByNote.get(note);
+        if (key != null) {
+            key.applyFill(pressedNotes.contains(note));
+        }
+    }
+
+    private void buildKeys() {
+        int whiteIndex = 0;
+        for (int note = FIRST_NOTE; note <= LAST_NOTE; note++) {
+            if (isWhite(note)) {
+                double x = whiteIndex * WHITE_KEY_WIDTH;
+                Rectangle shape = createRectangle(x, 0, WHITE_KEY_WIDTH, WHITE_KEY_HEIGHT);
+                Key key = new Key(note, true, shape);
+                shape.setFill(WHITE_KEY_COLOR);
+                shape.setStroke(Color.DARKGRAY);
+                keysByNote.put(note, key);
+                whiteKeys.add(key);
+                whiteIndex++;
+            } else {
+                double x = whiteIndex * WHITE_KEY_WIDTH - BLACK_KEY_WIDTH / 2.0;
+                Rectangle shape = createRectangle(x, 0, BLACK_KEY_WIDTH, BLACK_KEY_HEIGHT);
+                Key key = new Key(note, false, shape);
+                shape.setFill(BLACK_KEY_COLOR);
+                keysByNote.put(note, key);
+                blackKeys.add(key);
+            }
+        }
+    }
+
+    private Rectangle createRectangle(double x, double y, double width, double height) {
+        Rectangle rectangle = new Rectangle(width, height);
+        rectangle.setX(x);
+        rectangle.setY(y);
+        rectangle.setManaged(false);
+        return rectangle;
+    }
+
+    private void layoutKeys() {
+        getChildren().clear();
+        for (Key key : whiteKeys) {
+            getChildren().add(key.shape);
+        }
+        for (Key key : blackKeys) {
+            getChildren().add(key.shape);
+        }
+    }
+
+    private boolean isWhite(int note) {
+        return switch (Math.floorMod(note, 12)) {
+            case 0, 2, 4, 5, 7, 9, 11 -> true;
+            default -> false;
+        };
+    }
+
+    private static final class Key {
+        final int note;
+        final boolean white;
+        final Rectangle shape;
+
+        Key(int note, boolean white, Rectangle shape) {
+            this.note = note;
+            this.white = white;
+            this.shape = shape;
+        }
+
+        void applyFill(boolean pressed) {
+            if (white) {
+                shape.setFill(pressed ? WHITE_KEY_PRESSED_COLOR : WHITE_KEY_COLOR);
+            } else {
+                shape.setFill(pressed ? BLACK_KEY_PRESSED_COLOR : BLACK_KEY_COLOR);
+            }
+        }
+    }
+}

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module com.gmidi {
+    requires java.desktop;
+    requires javafx.controls;
+    requires javafx.graphics;
+
+    exports com.gmidi;
+    exports com.gmidi.cli;
+    exports com.gmidi.cli.interaction;
+    exports com.gmidi.midi;
+    exports com.gmidi.recorder;
+
+    opens com.gmidi.ui to javafx.graphics;
+}


### PR DESCRIPTION
## Summary
- improve the JavaFX recorder flow with reusable idle-state recovery, guarded alerts, and device selector updates so the UI no longer stalls after cancellations or stops
- add a `module-info.java` plus Gradle launcher defaults (module name and native-access flag) to silence JavaFX runtime warnings and prep the build for modular tooling
- document the modular JavaFX setup in the README, including manual run commands that supply the required module path and native-access flag

## Testing
- ./gradlew test *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d817b624f4832688b74b282aa7639c