### PR TITLE
Fix JavaFX runtime warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+    modularity.inferModulePath = true
 }
 
 application {
@@ -39,4 +40,12 @@ application {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(JavaExec).configureEach {
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
 }


### PR DESCRIPTION
## Summary
- enable Gradle's modularity inference so JavaFX runs on the module path
- ensure all JavaExec and Test tasks include the native-access JVM argument

## Testing
- Not run (Gradle wrapper JAR missing in repository)

------
https://chatgpt.com/codex/tasks/task_e_68d835f35ce4832680c8520f49380aa2