### PR TITLE
Upgrade JavaFX runtime configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,11 @@ repositories {
     mavenCentral()
 }
 
-def javafxVersion = '21.0.2'
+def javafxVersion = '23.0.2'
 def os = OperatingSystem.current()
 def platformClassifier = os.isWindows() ? 'win' : (os.isMacOsX() ? 'mac' : 'linux')
+
+def nativeAccessArg = '--enable-native-access=ALL-UNNAMED'
 
 dependencies {
     implementation "org.openjfx:javafx-controls:${javafxVersion}"
@@ -29,14 +31,22 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+    modularity.inferModulePath = true
 }
 
 application {
     mainModule = 'com.gmidi'
     mainClass = 'com.gmidi.App'
-    applicationDefaultJvmArgs = ['--enable-native-access=ALL-UNNAMED']
+    applicationDefaultJvmArgs = [nativeAccessArg]
 }
 
-tasks.named('test') {
+tasks.withType(JavaExec).configureEach {
+    modularity.inferModulePath = true
+    jvmArgs nativeAccessArg
+}
+
+tasks.withType(Test).configureEach {
     useJUnitPlatform()
+    modularity.inferModulePath = true
+    jvmArgs nativeAccessArg
 }


### PR DESCRIPTION
## Summary
- upgrade the JavaFX dependency version to 23.0.2 to remove warnings about deprecated Unsafe usage
- reuse the native-access JVM argument configuration across application, exec, and test tasks while inferring the module path for each

## Testing
- `./gradlew --version` *(fails: repository is missing gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d835f35ce4832680c8520f49380aa2