### PR TITLE
Disable unsafe Prism allocation for GUI launch

### DIFF
--- a/app/src/main/java/com/gmidi/App.java
+++ b/app/src/main/java/com/gmidi/App.java
@@ -18,6 +18,7 @@ public final class App {
 
     public static void main(String[] args) {
         if (wantsGui(args)) {
+            System.setProperty("prism.marlin.useUnsafe", "false");
             MidiRecorderApp.launchApp();
             return;
         }


### PR DESCRIPTION
## Summary
- set the `prism.marlin.useUnsafe` property before launching the GUI to avoid Unsafe allocation warnings

## Testing
- ./gradlew app:run --args="--gui" *(fails: gradle wrapper JAR missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c5baa54832680707e7d4f968eef