### PR TITLE
Add JavaFX modules to Gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,9 @@ def javafxVersion = '21.0.2'
 def nativeAccessArg = '--enable-native-access=ALL-UNNAMED'
 
 dependencies {
+    implementation "org.openjfx:javafx-controls:$javafxVersion"
+    implementation "org.openjfx:javafx-graphics:$javafxVersion"
+    implementation "org.openjfx:javafx-base:$javafxVersion"
     testImplementation libs.junit.jupiter
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
## Summary
- add explicit JavaFX controls, graphics, and base modules to the app module dependencies
- ensure the modular build can resolve the required JavaFX modules during compilation

## Testing
- not run (gradle wrapper jar missing in repository)


------
https://chatgpt.com/codex/tasks/task_e_68d8412291a08326ab8a0396e40e3dfa