### PR TITLE
Configure JavaFX dependencies per platform

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.14'
 }
 
 repositories {
@@ -8,9 +7,24 @@ repositories {
 }
 
 def javafxVersion = '21.0.2'
+def os = org.gradle.internal.os.OperatingSystem.current()
+def arch = System.getProperty('os.arch')
+
+def javafxPlatform =
+        os.isWindows() ? (arch == 'aarch64' ? 'win-aarch64' : arch == 'x86' ? 'win-x86' : 'win') :
+        os.isMacOsX() ? (arch == 'aarch64' ? 'mac-aarch64' : 'mac') :
+        os.isLinux() ? (arch == 'aarch64' ? 'linux-aarch64' : arch.startsWith('arm') ? 'linux-arm32' : 'linux') :
+        null
+
+if (javafxPlatform == null) {
+    throw new GradleException("Unsupported JavaFX platform for OS '${os}' and architecture '${arch}'")
+}
 def nativeAccessArg = '--enable-native-access=ALL-UNNAMED'
 
 dependencies {
+    implementation "org.openjfx:javafx-controls:$javafxVersion:$javafxPlatform"
+    implementation "org.openjfx:javafx-graphics:$javafxVersion:$javafxPlatform"
+    implementation "org.openjfx:javafx-base:$javafxVersion:$javafxPlatform"
     testImplementation libs.junit.jupiter
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -26,11 +40,6 @@ application {
     mainModule = 'com.gmidi'
     mainClass = 'com.gmidi.App'
     applicationDefaultJvmArgs = [nativeAccessArg]
-}
-
-javafx {
-    version = javafxVersion
-    modules = ['javafx.controls', 'javafx.graphics', 'javafx.base']
 }
 
 tasks.withType(JavaExec).configureEach {


### PR DESCRIPTION
## Summary
- remove the JavaFX Gradle plugin to avoid classifier-less dependencies
- detect the current OS and architecture to select the appropriate JavaFX platform classifier
- declare JavaFX controls, graphics, and base dependencies with the computed platform-specific classifier

## Testing
- not run (Gradle wrapper JAR missing from repository)


------
https://chatgpt.com/codex/tasks/task_e_68d8412291a08326ab8a0396e40e3dfa