### PR TITLE
Remove extra blank line after application block

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ application {
     mainClass = 'com.gmidi.App'
     applicationDefaultJvmArgs = [nativeAccessArg]
 }
-
 tasks.withType(JavaExec).configureEach {
     modularity.inferModulePath = true
     jvmArgs nativeAccessArg


### PR DESCRIPTION
## Summary
- remove the stray blank line between the `application` block and the `JavaExec` task configuration in `app/build.gradle`

## Testing
- ./gradlew :app:run

------
https://chatgpt.com/codex/tasks/task_e_68d84754c180832688913f191bf276a9