### PR TITLE
Guard canvas resize against zero dimensions

### DIFF
--- a/app/src/main/java/com/gmidi/MainApp.java
+++ b/app/src/main/java/com/gmidi/MainApp.java
@@ -41,8 +41,18 @@ public class MainApp extends Application {
         StackPane keyFallContainer = new StackPane(keyFallCanvas);
         keyFallContainer.getStyleClass().add("keyfall-container");
         keyFallContainer.setPadding(new Insets(12, 16, 16, 16));
-        keyFallContainer.widthProperty().addListener((obs, oldV, newV) -> keyFallCanvas.setWidth(newV.doubleValue()));
-        keyFallContainer.heightProperty().addListener((obs, oldV, newV) -> keyFallCanvas.setHeight(newV.doubleValue()));
+        keyFallContainer.widthProperty().addListener((obs, oldV, newV) -> {
+            double width = newV.doubleValue();
+            if (width > 0) {
+                keyFallCanvas.setWidth(width);
+            }
+        });
+        keyFallContainer.heightProperty().addListener((obs, oldV, newV) -> {
+            double height = newV.doubleValue();
+            if (height > 0) {
+                keyFallCanvas.setHeight(height);
+            }
+        });
 
         ComboBox<MidiService.MidiInput> deviceCombo = new ComboBox<>();
         deviceCombo.setPromptText("MIDI input");


### PR DESCRIPTION
## Summary
- avoid resizing the key fall canvas to a zero dimension when layout listeners fire
- prevent JavaFX from creating a null render target that triggered the runtime NPE

## Testing
- `./gradlew test` *(fails: gradle-wrapper.jar is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d85db8c11883268971a2b6333b20a3