### PR TITLE
Fix keyfall viewport sizing and restore animation

### DIFF
--- a/app/src/main/java/com/gmidi/MainApp.java
+++ b/app/src/main/java/com/gmidi/MainApp.java
@@ -37,11 +37,18 @@ public class MainApp extends Application {
         midiService = new MidiService();
 
         KeyboardView keyboardView = new KeyboardView();
+        keyboardView.setMaxWidth(Double.MAX_VALUE);
+
         KeyFallCanvas keyFallCanvas = new KeyFallCanvas();
-        StackPane keyFallContainer = new StackPane(keyFallCanvas);
-        keyFallContainer.getStyleClass().add("keyfall-container");
-        keyFallContainer.setPadding(new Insets(12, 16, 16, 16));
-        keyFallCanvas.bindTo(keyFallContainer);
+        StackPane keyFallViewport = new StackPane();
+        keyFallViewport.getStyleClass().add("keyfall-container");
+        keyFallViewport.setPadding(new Insets(12, 16, 16, 16));
+        keyFallViewport.getChildren().add(keyFallCanvas); // child 0: canvas
+        StackPane overlayLayer = new StackPane();
+        overlayLayer.setMouseTransparent(true);
+        overlayLayer.setPickOnBounds(false);
+        keyFallViewport.getChildren().add(overlayLayer); // child 1: overlays placeholder
+        keyFallCanvas.bindTo(keyFallViewport);
 
         ComboBox<MidiService.MidiInput> deviceCombo = getMidiInputComboBox();
 
@@ -72,11 +79,11 @@ public class MainApp extends Application {
         toolbar.setPadding(new Insets(16, 18, 12, 18));
         toolbar.getStyleClass().add("toolbar");
 
-        VBox visualiser = new VBox(12, keyboardView, keyFallContainer);
-        visualiser.setPadding(new Insets(0, 0, 0, 0));
-        VBox.setVgrow(keyFallContainer, Priority.ALWAYS);
-        keyboardView.setMaxWidth(Double.MAX_VALUE);
-        keyFallContainer.setMaxWidth(Double.MAX_VALUE);
+        BorderPane visualiserPane = new BorderPane();
+        visualiserPane.setCenter(keyFallViewport);
+        BorderPane.setMargin(keyFallViewport, Insets.EMPTY);
+        visualiserPane.setBottom(keyboardView);
+        BorderPane.setMargin(keyboardView, new Insets(0, 16, 16, 16));
 
         ProgressBar progressBar = new ProgressBar(0);
         progressBar.setPrefWidth(Double.MAX_VALUE);
@@ -102,7 +109,7 @@ public class MainApp extends Application {
 
         BorderPane root = new BorderPane();
         root.setTop(toolbar);
-        root.setCenter(visualiser);
+        root.setCenter(visualiserPane);
         root.setBottom(bottom);
         root.getStyleClass().add("app-root");
 
@@ -123,7 +130,7 @@ public class MainApp extends Application {
                 midiService,
                 keyboardView,
                 keyFallCanvas,
-                visualiser,
+                visualiserPane,
                 deviceCombo,
                 midiRecordToggle,
                 videoRecordToggle,
@@ -145,6 +152,7 @@ public class MainApp extends Application {
         stage.setMinWidth(960);
         stage.setMinHeight(640);
         stage.show();
+        controller.startAnimation();
     }
 
     private static ComboBox<MidiService.MidiInput> getMidiInputComboBox() {

--- a/app/src/main/java/com/gmidi/session/SessionController.java
+++ b/app/src/main/java/com/gmidi/session/SessionController.java
@@ -117,6 +117,13 @@ public class SessionController {
                 onAnimationFrame(now);
             }
         };
+    }
+
+    /**
+     * Starts the visualiser animation loop. This should be invoked once the scene has been shown so
+     * the viewport has valid bounds.
+     */
+    public void startAnimation() {
         animationTimer.start();
     }
 

--- a/app/src/main/java/com/gmidi/ui/KeyboardView.java
+++ b/app/src/main/java/com/gmidi/ui/KeyboardView.java
@@ -27,12 +27,11 @@ public class KeyboardView extends Region {
         getStyleClass().add("keyboard-view");
         getChildren().add(canvas);
         setPadding(new Insets(12, 16, 12, 16));
-        setMinHeight(100);
-        setPrefHeight(140);
+        setMinHeight(120);
+        setPrefHeight(160);
+        setMaxHeight(200);
         canvas.addEventHandler(MouseEvent.MOUSE_MOVED, e -> handleHover(e, true));
         canvas.addEventHandler(MouseEvent.MOUSE_EXITED, e -> handleHover(e, false));
-        widthProperty().addListener((obs, oldV, newV) -> redraw());
-        heightProperty().addListener((obs, oldV, newV) -> redraw());
     }
 
     public void press(int midiNote) {
@@ -87,17 +86,21 @@ public class KeyboardView extends Region {
 
     @Override
     protected void layoutChildren() {
-        double w = getWidth();
-        double h = getHeight();
-        canvas.setWidth(Math.max(200, w - getPadding().getLeft() - getPadding().getRight()));
-        canvas.setHeight(Math.max(60, h - getPadding().getTop() - getPadding().getBottom()));
-        canvas.relocate(getPadding().getLeft(), getPadding().getTop());
+        Insets padding = getPadding();
+        double contentWidth = Math.max(200, getWidth() - padding.getLeft() - padding.getRight());
+        double contentHeight = Math.max(60, getHeight() - padding.getTop() - padding.getBottom());
+        canvas.setWidth(contentWidth);
+        canvas.setHeight(contentHeight);
+        canvas.relocate(padding.getLeft(), padding.getTop());
         redraw();
     }
 
     private void redraw() {
         double width = canvas.getWidth();
         double height = canvas.getHeight();
+        if (width <= 0 || height <= 0) {
+            return;
+        }
         GraphicsContext gc = canvas.getGraphicsContext2D();
         gc.clearRect(0, 0, width, height);
 


### PR DESCRIPTION
## Summary
- update KeyFallCanvas to size itself from layout bounds only and clamp dimensions before redrawing
- refactor the session layout to use a StackPane viewport over a fixed-height keyboard while keeping the canvas on top
- start the animation timer after the stage is shown so note sprites render smoothly across the new layout

## Testing
- `./gradlew -q test` *(fails: gradle-wrapper.jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d873a90fdc832696dbe37638bcb54a