### PR TITLE
Normalize canvas sizing and improve FFmpeg defaults

### DIFF
--- a/app/src/main/java/com/gmidi/session/SessionController.java
+++ b/app/src/main/java/com/gmidi/session/SessionController.java
@@ -229,6 +229,16 @@ public class SessionController {
         currentVideoFile = outputDir.resolve(baseName + ".mp4");
         videoRecorder = new VideoRecorder();
         try {
+            double captureWidth = captureNode.getLayoutBounds().getWidth();
+            double captureHeight = captureNode.getLayoutBounds().getHeight();
+            int viewportW = (int) Math.round(captureWidth);
+            int viewportH = (int) Math.round(captureHeight);
+            System.out.printf("[Session] Capture viewport: %dx%d (video target %dx%d @ %d FPS)%n",
+                    viewportW,
+                    viewportH,
+                    videoSettings.getWidth(),
+                    videoSettings.getHeight(),
+                    videoSettings.getFps());
             videoRecorder.start(currentVideoFile, videoSettings);
             videoFrameIntervalNanos = Math.max(1L, Math.round(1_000_000_000.0 / Math.max(1, videoSettings.getFps())));
             lastVideoCaptureNanos = 0;

--- a/app/src/main/java/com/gmidi/video/FfmpegLocator.java
+++ b/app/src/main/java/com/gmidi/video/FfmpegLocator.java
@@ -22,16 +22,25 @@ public final class FfmpegLocator {
         Objects.requireNonNull(settings, "settings");
         Path configured = settings.getFfmpegExecutable();
         if (configured != null) {
-            Path normalised = configured.toAbsolutePath().normalize();
-            if (!Files.isRegularFile(normalised)) {
-                throw new IOException("Configured FFmpeg path is not a file: " + normalised);
-            }
-            if (!Files.isExecutable(normalised)) {
-                throw new IOException("Configured FFmpeg path is not executable: " + normalised);
-            }
-            return normalised.toString();
+            return normalizeConfigured(configured);
         }
 
+        return defaultExecutable();
+    }
+
+    public static String normalizeConfigured(Path configured) throws IOException {
+        Objects.requireNonNull(configured, "configured");
+        Path normalised = configured.toAbsolutePath().normalize();
+        if (!Files.isRegularFile(normalised)) {
+            throw new IOException("Configured FFmpeg path is not a file: " + normalised);
+        }
+        if (!Files.isExecutable(normalised)) {
+            throw new IOException("Configured FFmpeg path is not executable: " + normalised);
+        }
+        return normalised.toString();
+    }
+
+    public static String defaultExecutable() {
         String windowsDefault = windowsChocolateyExecutable();
         if (windowsDefault != null) {
             return windowsDefault;
@@ -43,20 +52,6 @@ public final class FfmpegLocator {
         }
 
         return "ffmpeg";
-    }
-
-    public static String effectiveExecutable(String configured) {
-        if (configured != null && !configured.isBlank()) {
-            try {
-                Path candidate = Paths.get(configured.trim());
-                if (Files.isRegularFile(candidate)) {
-                    return candidate.toAbsolutePath().toString();
-                }
-            } catch (InvalidPathException ignored) {
-            }
-        }
-        String windowsDefault = windowsChocolateyExecutable();
-        return windowsDefault != null ? windowsDefault : "ffmpeg";
     }
 
     public static String locateOnPath() {

--- a/app/src/main/java/com/gmidi/video/FfmpegLocator.java
+++ b/app/src/main/java/com/gmidi/video/FfmpegLocator.java
@@ -1,0 +1,99 @@
+package com.gmidi.video;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Locates the ffmpeg executable based on user configuration, sensible defaults, and the system PATH.
+ */
+public final class FfmpegLocator {
+
+    public static final String WINDOWS_CHOCOLATEY_PATH = "C:\\ProgramData\\chocolatey\\bin\\ffmpeg.exe";
+
+    private FfmpegLocator() {
+    }
+
+    public static String resolve(VideoSettings settings) throws IOException {
+        Objects.requireNonNull(settings, "settings");
+        Path configured = settings.getFfmpegExecutable();
+        if (configured != null) {
+            Path normalised = configured.toAbsolutePath().normalize();
+            if (!Files.isRegularFile(normalised)) {
+                throw new IOException("Configured FFmpeg path is not a file: " + normalised);
+            }
+            if (!Files.isExecutable(normalised)) {
+                throw new IOException("Configured FFmpeg path is not executable: " + normalised);
+            }
+            return normalised.toString();
+        }
+
+        String windowsDefault = windowsChocolateyExecutable();
+        if (windowsDefault != null) {
+            return windowsDefault;
+        }
+
+        String located = locateOnPath();
+        if (located != null) {
+            return located;
+        }
+
+        return "ffmpeg";
+    }
+
+    public static String effectiveExecutable(String configured) {
+        if (configured != null && !configured.isBlank()) {
+            try {
+                Path candidate = Paths.get(configured.trim());
+                if (Files.isRegularFile(candidate)) {
+                    return candidate.toAbsolutePath().toString();
+                }
+            } catch (InvalidPathException ignored) {
+            }
+        }
+        String windowsDefault = windowsChocolateyExecutable();
+        return windowsDefault != null ? windowsDefault : "ffmpeg";
+    }
+
+    public static String locateOnPath() {
+        String path = System.getenv("PATH");
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        String executable = isWindows() ? "ffmpeg.exe" : "ffmpeg";
+        String[] entries = path.split(File.pathSeparator);
+        for (String entry : entries) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            try {
+                Path candidate = Paths.get(entry.trim()).resolve(executable);
+                if (Files.isRegularFile(candidate) && Files.isExecutable(candidate)) {
+                    return candidate.toAbsolutePath().toString();
+                }
+            } catch (InvalidPathException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static String windowsChocolateyExecutable() {
+        if (!isWindows()) {
+            return null;
+        }
+        Path candidate = Paths.get(WINDOWS_CHOCOLATEY_PATH);
+        if (Files.isRegularFile(candidate) && Files.isExecutable(candidate)) {
+            return candidate.toAbsolutePath().toString();
+        }
+        return null;
+    }
+
+    private static boolean isWindows() {
+        String os = System.getProperty("os.name");
+        return os != null && os.toLowerCase().contains("win");
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the key fall canvas to even pixel dimensions and defer renders to avoid resize feedback
- add an FFmpeg locator with Windows defaults and UI validation so recordings work out of the box
- harden the video recorder command pipeline with even-dimension scaling, frame dropping, and better logging

## Testing
- `./gradlew test` *(fails: Gradle wrapper jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d877847bf48326a1af0096d639c2bc