### PR TITLE
Implement Synthesia-style falling key visualization

### DIFF
--- a/app/src/main/java/com/gmidi/session/SessionController.java
+++ b/app/src/main/java/com/gmidi/session/SessionController.java
@@ -95,6 +95,8 @@ public class SessionController {
         this.statusLabel = statusLabel;
         this.progressBar = progressBar;
 
+        this.keyFallCanvas.setOnImpact(keyboardView::flash);
+
         deviceCombo.setOnAction(e -> connectToSelectedDevice());
         midiRecordToggle.selectedProperty().addListener((obs, oldV, recording) -> {
             if (recording) {


### PR DESCRIPTION
## Summary
- refactor KeyFallCanvas to use constant-velocity falling trails with impact detection, fade-out, and resize-safe positioning
- add a keyboard flash animation driven by a lightweight AnimationTimer
- wire the falling note impact callback through SessionController so keyboard flashes trigger on trail contact

## Testing
- ./gradlew check *(fails: gradle wrapper jar unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d895b6b8cc8326ad6e65cb4ece809f