### PR TITLE
Remove dependency on internal AudioSynthesizer module

### DIFF
--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -2,7 +2,6 @@ module com.gmidi {
     requires java.desktop;
     requires javafx.controls;
     requires javafx.graphics;
-    requires jdk.synthesizer;
 
     exports com.gmidi;
     exports com.gmidi.midi;


### PR DESCRIPTION
## Summary
- remove the jdk.synthesizer module requirement from the application module
- wrap access to com.sun.media.sound.AudioSynthesizer via reflection so the code continues to work without module dependencies

## Testing
- ./gradlew build *(fails: Unable to access jarfile /workspace/gmidi/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d974ef7d6083269cedbeb879a4e3d0