### PR TITLE
Align visuals to master timeline clock

### DIFF
--- a/app/src/main/java/com/gmidi/util/Clock.java
+++ b/app/src/main/java/com/gmidi/util/Clock.java
@@ -1,0 +1,5 @@
+package com.gmidi.util;
+
+public interface Clock {
+    long nowMicros();
+}

--- a/app/src/main/java/com/gmidi/util/SequencerClock.java
+++ b/app/src/main/java/com/gmidi/util/SequencerClock.java
@@ -1,0 +1,16 @@
+package com.gmidi.util;
+
+import javax.sound.midi.Sequencer;
+
+public final class SequencerClock implements Clock {
+    private final Sequencer sequencer;
+
+    public SequencerClock(Sequencer sequencer) {
+        this.sequencer = sequencer;
+    }
+
+    @Override
+    public long nowMicros() {
+        return sequencer == null ? 0L : sequencer.getMicrosecondPosition();
+    }
+}

--- a/app/src/main/java/com/gmidi/util/SystemClock.java
+++ b/app/src/main/java/com/gmidi/util/SystemClock.java
@@ -1,0 +1,8 @@
+package com.gmidi.util;
+
+public final class SystemClock implements Clock {
+    @Override
+    public long nowMicros() {
+        return System.nanoTime() / 1_000L;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable microsecond clock abstraction for the UI and playback layers
- drive KeyFallCanvas rendering from supplied microsecond timestamps and expose renderAtMicros
- hook SessionController and MidiReplayer to the shared clock so sequencer playback stays visually in sync

## Testing
- ./gradlew test *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d987c40cd08326a60c320b99d7cc85