### PR TITLE
Improve layout responsiveness and dark theme styling

### DIFF
--- a/app/src/main/java/com/gmidi/session/SettingsDialog.java
+++ b/app/src/main/java/com/gmidi/session/SettingsDialog.java
@@ -18,6 +18,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.TextField;
+import javafx.scene.Scene;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.stage.DirectoryChooser;
@@ -45,6 +46,9 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 
     private final AtomicLong ffmpegProbeCounter = new AtomicLong();
+    private static final String DARK_THEME = Objects.requireNonNull(
+            SettingsDialog.class.getResource("/DarkTheme.css"))
+            .toExternalForm();
 
     public SettingsDialog(VideoSettings current,
                          String currentSoundFont,
@@ -59,6 +63,14 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
         getDialogPane().getStyleClass().add("settings-dialog");
         if (owner != null && owner.getScene() != null) {
             initOwner(owner.getScene().getWindow());
+        }
+        getDialogPane().sceneProperty().addListener((obs, oldScene, newScene) -> {
+            if (newScene != null) {
+                applyDarkTheme(newScene);
+            }
+        });
+        if (getDialogPane().getScene() != null) {
+            applyDarkTheme(getDialogPane().getScene());
         }
 
         GridPane grid = new GridPane();
@@ -235,6 +247,12 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
                     reverbChoice.getValue() == null ? MidiService.ReverbPreset.ROOM : reverbChoice.getValue();
             return new Result(updated, resolvedSoundFont, chosenInstrument, chosenCurve, transpose, chosenPreset);
         });
+    }
+
+    private void applyDarkTheme(Scene scene) {
+        if (scene != null && !scene.getStylesheets().contains(DARK_THEME)) {
+            scene.getStylesheets().add(DARK_THEME);
+        }
     }
 
     public static final class Result {

--- a/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
+++ b/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
@@ -7,7 +7,6 @@ import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
-import javafx.scene.transform.Affine;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -158,8 +157,8 @@ public class KeyFallCanvas extends Canvas {
     }
 
     private void applyBoundsOnce(double viewportW, double viewportH) {
-        double vw = clamp(viewportW, MIN_W, MAX_W * 1.25);
-        double vh = clamp(viewportH, MIN_H, MAX_H * 1.25);
+        double vw = clamp(viewportW, 1.0, MAX_W * 1.25);
+        double vh = clamp(viewportH, 1.0, MAX_H * 1.25);
         if (!Double.isFinite(vw) || !Double.isFinite(vh)) {
             return;
         }
@@ -336,7 +335,7 @@ public class KeyFallCanvas extends Canvas {
 
     private void draw(long nowMicros) {
         GraphicsContext g = getGraphicsContext2D();
-        g.setTransform(new Affine());
+        g.setTransform(1, 0, 0, 1, 0, 0);
         g.clearRect(0, 0, canvasW, canvasH);
 
         if (viewportWidth <= 0 || viewportHeight <= 0) {
@@ -345,6 +344,9 @@ public class KeyFallCanvas extends Canvas {
 
         g.save();
         g.scale(renderScaleX, renderScaleY);
+        g.beginPath();
+        g.rect(0, 0, viewportWidth, viewportHeight);
+        g.clip();
         g.setFill(NOTE_COLOR);
 
         final double keyboardLine = viewportHeight;

--- a/app/src/main/java/com/gmidi/ui/KeyboardView.java
+++ b/app/src/main/java/com/gmidi/ui/KeyboardView.java
@@ -52,6 +52,8 @@ public class KeyboardView extends Region {
         setMinHeight(MIN_HEIGHT);
         setPrefHeight(clampHeight(800 * DEFAULT_HEIGHT_RATIO));
         setMaxHeight(MAX_HEIGHT);
+        widthProperty().addListener((obs, oldV, newV) -> redraw());
+        heightProperty().addListener((obs, oldV, newV) -> redraw());
         canvas.addEventHandler(MouseEvent.MOUSE_MOVED, e -> handleHover(e, true));
         canvas.addEventHandler(MouseEvent.MOUSE_EXITED, e -> handleHover(e, false));
     }

--- a/app/src/main/resources/DarkTheme.css
+++ b/app/src/main/resources/DarkTheme.css
@@ -1,0 +1,49 @@
+/* Base */
+.root {
+  -fx-background-color: #0f1116;
+  -fx-text-fill: white;
+  -fx-text-base-color: white;
+  -fx-control-inner-background: #161a23;
+  -fx-accent: #2f6df6;
+}
+
+.label, .button, .toggle-button, .check-box, .radio-button, .tab-label, .menu-button, .menu-button .label {
+  -fx-text-fill: white;
+}
+
+/* Text inputs */
+.text-field, .password-field, .spinner .text-field {
+  -fx-text-fill: white;
+  -fx-prompt-text-fill: rgba(255,255,255,0.55);
+  -fx-background-color: #161a23, #161a23;
+  -fx-highlight-fill: #2f6df6;
+  -fx-highlight-text-fill: white;
+}
+
+/* ComboBox / ChoiceBox */
+.combo-box, .choice-box {
+  -fx-background-color: #161a23, #161a23;
+}
+
+.combo-box .list-cell, .choice-box .label {
+  -fx-text-fill: white;
+}
+
+.combo-box .arrow, .choice-box .arrow {
+  -fx-background-color: white;
+}
+
+/* Popup menus / lists */
+.list-view, .menu-button, .context-menu {
+  -fx-background-color: #161a23;
+}
+
+.list-cell, .menu-item > .label {
+  -fx-text-fill: white;
+}
+
+/* Disable focus ring glare */
+.focused {
+  -fx-faint-focus-color: rgba(47,109,246,0.15);
+  -fx-focus-color: #2f6df6;
+}


### PR DESCRIPTION
## Summary
- anchor the key-fall canvas inside a clipped viewport and bind the keyboard height to the scene so resizing keeps both visible
- clamp key-fall canvas backing buffers to the viewport while reusing textures and clipping draws to the logical view
- refresh keyboard redraw hooks and apply a shared dark theme stylesheet, including the settings dialog

## Testing
- ./gradlew test *(fails: gradle-wrapper.jar missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d98d76f40c8326bac3a6921b9cb18e