### PR TITLE
Iteration 3 — Velocity→Audio + Offline WAV render + Perfect A/V Sync

### DIFF
--- a/app/src/main/java/com/gmidi/midi/OfflineAudioRenderer.java
+++ b/app/src/main/java/com/gmidi/midi/OfflineAudioRenderer.java
@@ -1,0 +1,298 @@
+package com.gmidi.midi;
+
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MetaMessage;
+import javax.sound.midi.MidiChannel;
+import javax.sound.midi.MidiEvent;
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.Sequence;
+import javax.sound.midi.Sequencer;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.Soundbank;
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Utility class that renders MIDI sequences to audio files offline. */
+public final class OfflineAudioRenderer {
+
+    private OfflineAudioRenderer() {
+    }
+
+    public static Sequence prepareSequence(Sequence source,
+                                           MidiService.MidiProgram program,
+                                           int transposeSemis) throws InvalidMidiDataException {
+        if (source == null) {
+            throw new IllegalArgumentException("source sequence null");
+        }
+        Sequence prepared = new Sequence(source.getDivisionType(), source.getResolution());
+        javax.sound.midi.Track[] srcTracks = source.getTracks();
+        List<javax.sound.midi.Track> dstTracks = new ArrayList<>(srcTracks.length);
+        for (int i = 0; i < srcTracks.length; i++) {
+            dstTracks.add(prepared.createTrack());
+        }
+        long maxTick = 0;
+        for (int i = 0; i < srcTracks.length; i++) {
+            javax.sound.midi.Track src = srcTracks[i];
+            javax.sound.midi.Track dst = dstTracks.get(i);
+            for (int j = 0; j < src.size(); j++) {
+                MidiEvent event = src.get(j);
+                MidiMessage message = event.getMessage();
+                MidiMessage copy = cloneWithTranspose(message, transposeSemis);
+                dst.add(new MidiEvent(copy, event.getTick()));
+                if (event.getTick() > maxTick) {
+                    maxTick = event.getTick();
+                }
+            }
+        }
+        if (prepared.getTracks().length == 0) {
+            prepared.createTrack();
+        }
+        insertProgramChange(prepared.getTracks()[0], program);
+        addEndOfTrack(prepared, maxTick);
+        return prepared;
+    }
+
+    public static void renderWav(Sequence sequence,
+                                 MidiService.MidiProgram program,
+                                 int transposeSemis,
+                                 VelocityMap velocityMap,
+                                 MidiService.ReverbPreset reverbPreset,
+                                 Soundbank customSoundbank,
+                                 File outputFile) throws Exception {
+        if (sequence == null) {
+            throw new IllegalArgumentException("sequence null");
+        }
+        if (velocityMap == null) {
+            throw new IllegalArgumentException("velocity map null");
+        }
+        if (outputFile == null) {
+            throw new IllegalArgumentException("output file null");
+        }
+        File parent = outputFile.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        Sequence playable = prepareSequence(sequence, program, transposeSemis);
+        AudioSynth synth = AudioSynth.create();
+        AudioFormat format = new AudioFormat(44_100f, 16, 2, true, false);
+        try (AudioSynth ignored = synth;
+             AudioInputStream stream = synth.openStream(format);
+             BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+            if (customSoundbank != null) {
+                synth.loadSoundbank(customSoundbank);
+            }
+            applyReverb(synth.getChannels(), reverbPreset);
+            Sequencer sequencer = MidiSystem.getSequencer(false);
+            sequencer.open();
+            try {
+                try (TransmitterLink link = new TransmitterLink(sequencer.getTransmitter(),
+                        new VelocityReceiver(synth.getReceiver(), velocityMap))) {
+                    sequencer.setSequence(playable);
+                    sequencer.setTickPosition(0);
+                    sequencer.start();
+                    AudioSystem.write(stream, AudioFileFormat.Type.WAVE, out);
+                    sequencer.stop();
+                }
+            } finally {
+                sequencer.close();
+            }
+        }
+    }
+
+    private static MidiMessage cloneWithTranspose(MidiMessage message, int semis) {
+        if (!(message instanceof ShortMessage shortMessage)) {
+            return (MidiMessage) message.clone();
+        }
+        int command = shortMessage.getCommand();
+        if ((command == ShortMessage.NOTE_ON || command == ShortMessage.NOTE_OFF)
+                && shortMessage.getChannel() != 9 && semis != 0) {
+            int note = clamp7bit(shortMessage.getData1() + semis);
+            int velocity = shortMessage.getData2();
+            try {
+                ShortMessage shifted = new ShortMessage();
+                shifted.setMessage(command, shortMessage.getChannel(), note, velocity);
+                return shifted;
+            } catch (InvalidMidiDataException ignored) {
+                // fall back to clone
+            }
+        }
+        return (MidiMessage) message.clone();
+    }
+
+    private static void insertProgramChange(javax.sound.midi.Track track,
+                                            MidiService.MidiProgram program) throws InvalidMidiDataException {
+        MidiService.MidiProgram patch = program != null ? program : new MidiService.MidiProgram(0, 0, 0, "GM Program 0");
+        ShortMessage msb = new ShortMessage(ShortMessage.CONTROL_CHANGE, 0, 0, clamp7bit(patch.bankMsb()));
+        ShortMessage lsb = new ShortMessage(ShortMessage.CONTROL_CHANGE, 0, 32, clamp7bit(patch.bankLsb()));
+        ShortMessage pc = new ShortMessage(ShortMessage.PROGRAM_CHANGE, 0, clamp7bit(patch.program()), 0);
+        track.add(new MidiEvent(msb, 0));
+        track.add(new MidiEvent(lsb, 0));
+        track.add(new MidiEvent(pc, 0));
+    }
+
+    private static void addEndOfTrack(Sequence sequence, long maxTick) throws InvalidMidiDataException {
+        long tick = Math.max(maxTick + sequence.getResolution(), sequence.getResolution());
+        MetaMessage end = new MetaMessage();
+        end.setMessage(0x2F, new byte[0], 0);
+        sequence.getTracks()[0].add(new MidiEvent(end, tick));
+    }
+
+    private static void applyReverb(MidiChannel[] channels, MidiService.ReverbPreset preset) {
+        MidiService.ReverbPreset target = preset != null ? preset : MidiService.ReverbPreset.ROOM;
+        if (channels == null) {
+            return;
+        }
+        for (MidiChannel channel : channels) {
+            if (channel != null) {
+                channel.controlChange(91, clamp7bit(target.reverbCc()));
+                channel.controlChange(93, clamp7bit(target.chorusCc()));
+            }
+        }
+    }
+
+    private static int clamp7bit(int value) {
+        if (value < 0) {
+            return 0;
+        }
+        if (value > 127) {
+            return 127;
+        }
+        return value;
+    }
+
+    private static final class VelocityReceiver implements Receiver {
+        private final Receiver out;
+        private final VelocityMap velocityMap;
+
+        private VelocityReceiver(Receiver out, VelocityMap velocityMap) {
+            this.out = out;
+            this.velocityMap = velocityMap;
+        }
+
+        @Override
+        public void send(MidiMessage message, long timeStamp) {
+            if (message instanceof ShortMessage shortMessage) {
+                int command = shortMessage.getCommand();
+                if (command == ShortMessage.NOTE_ON) {
+                    int velocity = shortMessage.getData2();
+                    if (velocity > 0) {
+                        int mapped = velocityMap.map(velocity);
+                        if (mapped != velocity) {
+                            try {
+                                ShortMessage remapped = new ShortMessage();
+                                remapped.setMessage(ShortMessage.NOTE_ON,
+                                        shortMessage.getChannel(),
+                                        shortMessage.getData1(),
+                                        mapped);
+                                out.send(remapped, timeStamp);
+                                return;
+                            } catch (InvalidMidiDataException ignored) {
+                            }
+                        }
+                    }
+                }
+            }
+            out.send(message, timeStamp);
+        }
+
+        @Override
+        public void close() {
+            out.close();
+        }
+    }
+
+    private static final class TransmitterLink implements AutoCloseable {
+        private final javax.sound.midi.Transmitter transmitter;
+        private final Receiver receiver;
+
+        private TransmitterLink(javax.sound.midi.Transmitter transmitter, Receiver receiver) {
+            this.transmitter = transmitter;
+            this.receiver = receiver;
+            this.transmitter.setReceiver(receiver);
+        }
+
+        @Override
+        public void close() {
+            transmitter.close();
+            receiver.close();
+        }
+    }
+
+    private interface AudioSynth extends AutoCloseable {
+        AudioInputStream openStream(AudioFormat format) throws Exception;
+
+        Receiver getReceiver() throws Exception;
+
+        MidiChannel[] getChannels();
+
+        void loadSoundbank(Soundbank bank) throws Exception;
+
+        @Override
+        void close() throws Exception;
+
+        static AudioSynth create() throws Exception {
+            Class<?> clazz = Class.forName("com.sun.media.sound.SoftSynthesizer");
+            Constructor<?> ctor = clazz.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            Object instance = ctor.newInstance();
+            return new ReflectionAudioSynth(instance);
+        }
+    }
+
+    private static final class ReflectionAudioSynth implements AudioSynth {
+        private final Object synth;
+        private final javax.sound.midi.Synthesizer asSynth;
+        private final Map<String, Object> openParams = new HashMap<>();
+
+        private ReflectionAudioSynth(Object synth) {
+            this.synth = synth;
+            this.asSynth = (javax.sound.midi.Synthesizer) synth;
+        }
+
+        @Override
+        public AudioInputStream openStream(AudioFormat format) throws Exception {
+            return (AudioInputStream) synth.getClass()
+                    .getMethod("openStream", AudioFormat.class, Map.class)
+                    .invoke(synth, format, openParams);
+        }
+
+        @Override
+        public Receiver getReceiver() throws Exception {
+            return asSynth.getReceiver();
+        }
+
+        @Override
+        public MidiChannel[] getChannels() {
+            return asSynth.getChannels();
+        }
+
+        @Override
+        public void loadSoundbank(Soundbank bank) throws Exception {
+            if (bank != null) {
+                Soundbank defaultBank = asSynth.getDefaultSoundbank();
+                if (defaultBank != null) {
+                    asSynth.unloadAllInstruments(defaultBank);
+                }
+                asSynth.loadAllInstruments(bank);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            asSynth.close();
+        }
+    }
+}

--- a/app/src/main/java/com/gmidi/midi/VelCurve.java
+++ b/app/src/main/java/com/gmidi/midi/VelCurve.java
@@ -1,0 +1,7 @@
+package com.gmidi.midi;
+
+public enum VelCurve {
+    LINEAR,
+    SOFT,
+    HARD
+}

--- a/app/src/main/java/com/gmidi/midi/VelocityMap.java
+++ b/app/src/main/java/com/gmidi/midi/VelocityMap.java
@@ -1,0 +1,34 @@
+package com.gmidi.midi;
+
+/**
+ * Shared velocity mapper so audio, visuals, and exports stay perfectly aligned.
+ */
+public final class VelocityMap {
+
+    private VelCurve curve = VelCurve.LINEAR;
+
+    public void setCurve(VelCurve c) {
+        curve = c == null ? VelCurve.LINEAR : c;
+    }
+
+    public VelCurve getCurve() {
+        return curve;
+    }
+
+    /**
+     * Maps a NOTE_ON velocity in the range 1..127 using the configured curve. Zero is preserved.
+     */
+    public int map(int velocity) {
+        if (velocity <= 0) {
+            return 0;
+        }
+        double x = Math.max(1, Math.min(127, velocity)) / 127.0;
+        double y = switch (curve) {
+            case SOFT -> Math.sqrt(x);
+            case HARD -> x * x;
+            default -> x;
+        };
+        int out = (int) Math.round(1 + y * 126);
+        return Math.max(1, Math.min(127, out));
+    }
+}

--- a/app/src/main/java/com/gmidi/session/SettingsDialog.java
+++ b/app/src/main/java/com/gmidi/session/SettingsDialog.java
@@ -1,7 +1,7 @@
 package com.gmidi.session;
 
 import com.gmidi.midi.MidiService;
-import com.gmidi.ui.KeyFallCanvas.VelCurve;
+import com.gmidi.midi.VelCurve;
 import com.gmidi.video.FfmpegLocator;
 import com.gmidi.video.VideoSettings;
 import javafx.application.Platform;

--- a/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
+++ b/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
@@ -1,5 +1,6 @@
 package com.gmidi.ui;
 
+import com.gmidi.midi.VelCurve;
 import javafx.animation.AnimationTimer;
 import javafx.beans.InvalidationListener;
 import javafx.geometry.Bounds;
@@ -235,7 +236,7 @@ public class KeyFallCanvas extends Canvas {
         note.spawnMicros = resolveTimestampMicros(tNanos);
         note.impacted = false;
         note.impactMicros = 0;
-        int clampedVelocity = Math.max(1, Math.min(127, velocity));
+        int clampedVelocity = Math.max(0, Math.min(127, velocity));
         double mapped = mapVelocity(clampedVelocity);
         note.trailThickness = lerp(MIN_TRAIL_THICKNESS, MAX_TRAIL_THICKNESS, mapped);
         note.baseAlpha = lerp(MIN_TRAIL_ALPHA, MAX_TRAIL_ALPHA, mapped);
@@ -437,19 +438,13 @@ public class KeyFallCanvas extends Canvas {
         double intensity;
     }
 
-    public enum VelCurve {
-        LINEAR,
-        SOFT,
-        HARD // Add more entries here to experiment with custom curves.
-    }
-
     private double mapVelocity(int velocity) {
-        double x = clamp(velocity, 1, 127) / 127.0;
-        return switch (velCurve) {
-            case SOFT -> Math.sqrt(x);
-            case HARD -> x * x;
-            default -> x;
-        };
+        if (velocity <= 0) {
+            return 0.0;
+        }
+        int clamped = Math.max(1, Math.min(127, velocity));
+        double norm = (clamped - 1) / 126.0;
+        return clamp(norm, 0.0, 1.0);
     }
 
     private double lerp(double min, double max, double t) {


### PR DESCRIPTION
## Summary
* Added shared `VelCurve` enum and `VelocityMap` class so live MIDI, replays, and exports share the same velocity curve logic.
* Updated `MidiService` to apply mapped velocities before sending NOTE_ON events, expose velocity and soundbank getters, and accept curve updates.
* Reworked `MidiReplayer` to wrap both synth and visual receivers with a `VelocityReceiver`, added sequence length access, and removed legacy WAV rendering (now handled elsewhere).
* Introduced `OfflineAudioRenderer` for deterministic WAV rendering with transpose, velocity, reverb, and soundfont support.
* Updated `KeyFallCanvas` to consume mapped velocities through the shared map, keeping visuals aligned with audio intensity.
* Integrated velocity curve settings with `SessionController` and `SettingsDialog`, ensured shared map drives visuals/audio, and added offline export that renders audio (WAV) and video frame-by-frame before muxing via ffmpeg.
* Extended `VideoRecorder` with a manual frame-push mode (`beginFramePush`, `pushFrame`, `end`), allowing offline exports to avoid dropped frames.

## Outstanding TODOs
1. `app/src/main/java/com/gmidi/session/SessionController.java`  
   * Lines around 697-860: Offline export currently runs on a background thread but snapshots occur synchronously via `runOnFxAndWait`. Evaluate UI responsiveness for long exports and consider progress feedback or cancellation hooks.
   * Ensure `releaseAllKeys()` doesn’t conflict with concurrent live playback. Currently we call it during export finalization; review integration with live session state.

2. `app/src/main/java/com/gmidi/midi/OfflineAudioRenderer.java`  
   * Review soundbank loading/unloading for Gervill. We unload default bank only when custom soundbank provided; confirm this matches real-time synth behavior.

3. `app/src/main/java/com/gmidi/video/VideoRecorder.java`  
   * Manual mode writes frames sequentially; consider buffering for performance if future exports require scaling.

## Testing Status
* `./gradlew check` fails immediately because `gradle/wrapper/gradle-wrapper.jar` is missing from the repo. No compilation/tests were executed. New code paths (offline export, velocity mapping) remain unverified by automated tests. Recommend adding integration tests or running `./gradlew check` once the wrapper is restored.


------
https://chatgpt.com/codex/tasks/task_e_68d991cfd2dc83269f23ea4fe8064540