### PR TITLE
Fix velocity curve visibility across threads

### DIFF
--- a/app/src/main/java/com/gmidi/midi/VelocityMap.java
+++ b/app/src/main/java/com/gmidi/midi/VelocityMap.java
@@ -5,7 +5,7 @@ package com.gmidi.midi;
  */
 public final class VelocityMap {
 
-    private VelCurve curve = VelCurve.LINEAR;
+    private volatile VelCurve curve = VelCurve.LINEAR;
 
     public void setCurve(VelCurve c) {
         curve = c == null ? VelCurve.LINEAR : c;


### PR DESCRIPTION
## Summary
- make the velocity curve reference volatile so device threads observe UI updates immediately
- capture export parameters in final variables before starting the background thread to keep lambda captures effectively final

## Testing
- ./gradlew check *(fails: Unable to access jarfile /workspace/gmidi/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d99bca0a5883269e390b4fd17dc014