### PR TITLE
Persist session settings and add visual offset control

### DIFF
--- a/app/src/main/java/com/gmidi/Prefs.java
+++ b/app/src/main/java/com/gmidi/Prefs.java
@@ -1,0 +1,98 @@
+package com.gmidi;
+
+import java.util.prefs.Preferences;
+
+public final class Prefs {
+    private static final Preferences P = Preferences.userNodeForPackage(Prefs.class);
+
+    public static void putSoundFontPath(String s) {
+        P.put("sf2", s == null ? "" : s);
+    }
+
+    public static String getSoundFontPath() {
+        return P.get("sf2", "");
+    }
+
+    public static void putProgram(int msb, int lsb, int prog, String name) {
+        P.putInt("bankMsb", msb);
+        P.putInt("bankLsb", lsb);
+        P.putInt("program", prog);
+        P.put("progName", name == null ? "" : name);
+    }
+
+    public static int bankMsb() {
+        return P.getInt("bankMsb", 0);
+    }
+
+    public static int bankLsb() {
+        return P.getInt("bankLsb", 0);
+    }
+
+    public static int program() {
+        return P.getInt("program", 0);
+    }
+
+    public static String progName() {
+        return P.get("progName", "GM Program 0");
+    }
+
+    public static void putTranspose(int v) {
+        P.putInt("transpose", v);
+    }
+
+    public static int getTranspose() {
+        return P.getInt("transpose", 0);
+    }
+
+    public static void putReverb(String label) {
+        P.put("reverb", label);
+    }
+
+    public static String getReverb() {
+        return P.get("reverb", "Room");
+    }
+
+    public static void putVelCurve(String v) {
+        P.put("velCurve", v);
+    }
+
+    public static String getVelCurve() {
+        return P.get("velCurve", "LINEAR");
+    }
+
+    public static void putFallSeconds(double s) {
+        P.putDouble("fallSeconds", s);
+    }
+
+    public static double getFallSeconds() {
+        return P.getDouble("fallSeconds", 10.0);
+    }
+
+    public static void putKbRatio(double r) {
+        P.putDouble("kbRatio", r);
+    }
+
+    public static double getKbRatio() {
+        return P.getDouble("kbRatio", 0.24);
+    }
+
+    public static void putLastExportDir(String d) {
+        P.put("lastExportDir", d == null ? "" : d);
+    }
+
+    public static String getLastExportDir() {
+        return P.get("lastExportDir", "");
+    }
+
+    public static void putVisualOffsetMillis(int ms) {
+        P.putInt("visualOffsetMs", ms);
+    }
+
+    public static int getVisualOffsetMillis() {
+        return P.getInt("visualOffsetMs", 0);
+    }
+
+    private Prefs() {
+    }
+}
+

--- a/app/src/main/java/com/gmidi/midi/MidiService.java
+++ b/app/src/main/java/com/gmidi/midi/MidiService.java
@@ -173,6 +173,10 @@ public class MidiService {
         return customSoundbank;
     }
 
+    public synchronized Soundbank getCustomSoundbankOrNull() {
+        return customSoundbank;
+    }
+
     public synchronized List<String> getInstrumentNames() {
         return List.copyOf(instrumentNames);
     }

--- a/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
+++ b/app/src/main/java/com/gmidi/ui/KeyFallCanvas.java
@@ -78,6 +78,7 @@ public class KeyFallCanvas extends Canvas {
     private VelCurve velCurve = VelCurve.LINEAR;
 
     private long lastTickMicros;
+    private long visualOffsetMicros;
 
     public KeyFallCanvas() {
         super(1, 1);
@@ -274,7 +275,7 @@ public class KeyFallCanvas extends Canvas {
     }
 
     public void tickMicros(long nowMicros) {
-        long resolvedMicros = resolveTickMicros(nowMicros);
+        long resolvedMicros = resolveTickMicros(nowMicros + visualOffsetMicros);
         if (viewportHeight <= 0 || viewportWidth <= 0) {
             return;
         }
@@ -288,7 +289,7 @@ public class KeyFallCanvas extends Canvas {
     }
 
     public void renderAtMicros(long micros) {
-        long resolvedMicros = resolveTickMicros(micros);
+        long resolvedMicros = resolveTickMicros(micros + visualOffsetMicros);
         if (viewportHeight <= 0 || viewportWidth <= 0) {
             return;
         }
@@ -405,6 +406,11 @@ public class KeyFallCanvas extends Canvas {
 
     private void requestRender() {
         renderRequested = true;
+    }
+
+    public void setVisualOffsetMillis(int ms) {
+        visualOffsetMicros = ms * 1_000L;
+        requestRender();
     }
 
     private long resolveTimestampMicros(long nanos) {


### PR DESCRIPTION
## Summary
- add a shared Preferences helper and persist SoundFont, instrument, visual, and export settings
- insert bank/program and reverb messages at tick 0 for replayed and rendered MIDI sequences
- add visual offset handling and tighten UI sizing/clamping for better responsiveness

## Testing
- ./gradlew check *(fails: Unable to access jarfile /workspace/gmidi/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d9abbf50608326bc5223bd4f398cc6