### PR TITLE
Avoid direct SoftSynthesizer dependency

### DIFF
--- a/app/src/main/java/com/gmidi/midi/OfflineAudioRenderer.java
+++ b/app/src/main/java/com/gmidi/midi/OfflineAudioRenderer.java
@@ -1,7 +1,5 @@
 package com.gmidi.midi;
 
-import com.sun.media.sound.SoftSynthesizer;
-
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MetaMessage;
 import javax.sound.midi.MidiChannel;
@@ -21,10 +19,12 @@ import javax.sound.sampled.AudioSystem;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongConsumer;
 
@@ -111,76 +111,78 @@ public final class OfflineAudioRenderer {
         }
         Sequence playable = prepareSequence(sequence, program, reverbPreset, transposeSemis);
         AudioFormat format = new AudioFormat(44_100f, 16, 2, true, false);
-        SoftSynthesizer synth = new SoftSynthesizer();
-        AudioInputStream stream = synth.openStream(format, null);
-        try (AudioInputStream ignored = stream;
-             BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-            if (customSoundbank != null) {
-                Soundbank defaultBank = synth.getDefaultSoundbank();
-                if (defaultBank != null) {
-                    synth.unloadAllInstruments(defaultBank);
-                }
-                synth.loadAllInstruments(customSoundbank);
-            }
-            applyReverb(synth.getChannels(), reverbPreset);
-            Sequencer sequencer = MidiSystem.getSequencer(false);
-            sequencer.open();
-            try {
-                Transmitter transmitter = sequencer.getTransmitter();
-                Receiver synthReceiver = synth.getReceiver();
-                Receiver velocityReceiver = new VelocityReceiver(synthReceiver, velocityMap);
-                transmitter.setReceiver(velocityReceiver);
-                try {
-                    sequencer.setSequence(playable);
-                    sequencer.setTickPosition(0);
-                    AtomicBoolean running = new AtomicBoolean(true);
-                    Thread monitor = null;
-                    if (progressMicros != null || cancelFlag != null) {
-                        monitor = new Thread(() -> {
-                            try {
-                                while (running.get()) {
-                                    if (cancelFlag != null && cancelFlag.get()) {
-                                        sequencer.stop();
-                                        break;
-                                    }
-                                    if (progressMicros != null) {
-                                        progressMicros.accept(Math.max(0L, sequencer.getMicrosecondPosition()));
-                                    }
-                                    Thread.sleep(100);
-                                }
-                            } catch (InterruptedException s) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }, "gmidi-audio-progress");
-                        monitor.setDaemon(true);
-                        monitor.start();
+        SoftSynthesizerFacade synth = SoftSynthesizerFacade.create();
+        try {
+            AudioInputStream stream = synth.openStream(format);
+            try (AudioInputStream ignored = stream;
+                 BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+                if (customSoundbank != null) {
+                    Soundbank defaultBank = synth.getDefaultSoundbank();
+                    if (defaultBank != null) {
+                        synth.unloadAllInstruments(defaultBank);
                     }
+                    synth.loadAllInstruments(customSoundbank);
+                }
+                applyReverb(synth.getChannels(), reverbPreset);
+                Sequencer sequencer = MidiSystem.getSequencer(false);
+                sequencer.open();
+                try {
+                    Transmitter transmitter = sequencer.getTransmitter();
+                    Receiver synthReceiver = synth.getReceiver();
+                    Receiver velocityReceiver = new VelocityReceiver(synthReceiver, velocityMap);
+                    transmitter.setReceiver(velocityReceiver);
                     try {
-                        sequencer.start();
-                        AudioSystem.write(stream, AudioFileFormat.Type.WAVE, out);
-                        sequencer.stop();
-                    } finally {
-                        running.set(false);
-                        if (monitor != null) {
-                            try {
-                                monitor.join();
-                            } catch (InterruptedException ex) {
-                                Thread.currentThread().interrupt();
+                        sequencer.setSequence(playable);
+                        sequencer.setTickPosition(0);
+                        AtomicBoolean running = new AtomicBoolean(true);
+                        Thread monitor = null;
+                        if (progressMicros != null || cancelFlag != null) {
+                            monitor = new Thread(() -> {
+                                try {
+                                    while (running.get()) {
+                                        if (cancelFlag != null && cancelFlag.get()) {
+                                            sequencer.stop();
+                                            break;
+                                        }
+                                        if (progressMicros != null) {
+                                            progressMicros.accept(Math.max(0L, sequencer.getMicrosecondPosition()));
+                                        }
+                                        Thread.sleep(100);
+                                    }
+                                } catch (InterruptedException s) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            }, "gmidi-audio-progress");
+                            monitor.setDaemon(true);
+                            monitor.start();
+                        }
+                        try {
+                            sequencer.start();
+                            AudioSystem.write(stream, AudioFileFormat.Type.WAVE, out);
+                            sequencer.stop();
+                        } finally {
+                            running.set(false);
+                            if (monitor != null) {
+                                try {
+                                    monitor.join();
+                                } catch (InterruptedException ex) {
+                                    Thread.currentThread().interrupt();
+                                }
                             }
                         }
-                    }
-                    if (progressMicros != null) {
-                        progressMicros.accept(sequence.getMicrosecondLength());
-                    }
-                    if (cancelFlag != null && cancelFlag.get()) {
-                        throw new InterruptedException("Audio render cancelled");
+                        if (progressMicros != null) {
+                            progressMicros.accept(sequence.getMicrosecondLength());
+                        }
+                        if (cancelFlag != null && cancelFlag.get()) {
+                            throw new InterruptedException("Audio render cancelled");
+                        }
+                    } finally {
+                        velocityReceiver.close();
+                        transmitter.close();
                     }
                 } finally {
-                    velocityReceiver.close();
-                    transmitter.close();
+                    sequencer.close();
                 }
-            } finally {
-                sequencer.close();
             }
         } finally {
             synth.close();
@@ -276,6 +278,116 @@ public final class OfflineAudioRenderer {
         @Override
         public void close() {
             out.close();
+        }
+    }
+
+    private static final class SoftSynthesizerFacade implements AutoCloseable {
+        private final Object synth;
+        private final Method openStream;
+        private final Method getDefaultSoundbank;
+        private final Method unloadAllInstruments;
+        private final Method loadAllInstruments;
+        private final Method getChannels;
+        private final Method getReceiver;
+        private final Method close;
+
+        private SoftSynthesizerFacade(Object synth,
+                                      Method openStream,
+                                      Method getDefaultSoundbank,
+                                      Method unloadAllInstruments,
+                                      Method loadAllInstruments,
+                                      Method getChannels,
+                                      Method getReceiver,
+                                      Method close) {
+            this.synth = synth;
+            this.openStream = openStream;
+            this.getDefaultSoundbank = getDefaultSoundbank;
+            this.unloadAllInstruments = unloadAllInstruments;
+            this.loadAllInstruments = loadAllInstruments;
+            this.getChannels = getChannels;
+            this.getReceiver = getReceiver;
+            this.close = close;
+        }
+
+        static SoftSynthesizerFacade create() {
+            try {
+                Class<?> synthClass = Class.forName("com.sun.media.sound.SoftSynthesizer");
+                Object synth = synthClass.getConstructor().newInstance();
+                Method openStream = synthClass.getMethod("openStream", AudioFormat.class, Map.class);
+                Method getDefaultSoundbank = synthClass.getMethod("getDefaultSoundbank");
+                Method unloadAllInstruments = synthClass.getMethod("unloadAllInstruments", Soundbank.class);
+                Method loadAllInstruments = synthClass.getMethod("loadAllInstruments", Soundbank.class);
+                Method getChannels = synthClass.getMethod("getChannels");
+                Method getReceiver = synthClass.getMethod("getReceiver");
+                Method close = synthClass.getMethod("close");
+                return new SoftSynthesizerFacade(synth,
+                        openStream,
+                        getDefaultSoundbank,
+                        unloadAllInstruments,
+                        loadAllInstruments,
+                        getChannels,
+                        getReceiver,
+                        close);
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException("SoftSynthesizer is not available in this runtime", ex);
+            }
+        }
+
+        AudioInputStream openStream(AudioFormat format) {
+            try {
+                return (AudioInputStream) openStream.invoke(synth, format, null);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to open SoftSynthesizer stream", ex);
+            }
+        }
+
+        Soundbank getDefaultSoundbank() {
+            try {
+                return (Soundbank) getDefaultSoundbank.invoke(synth);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to query SoftSynthesizer soundbank", ex);
+            }
+        }
+
+        void unloadAllInstruments(Soundbank soundbank) {
+            try {
+                unloadAllInstruments.invoke(synth, soundbank);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to unload SoftSynthesizer instruments", ex);
+            }
+        }
+
+        void loadAllInstruments(Soundbank soundbank) {
+            try {
+                loadAllInstruments.invoke(synth, soundbank);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to load SoftSynthesizer instruments", ex);
+            }
+        }
+
+        MidiChannel[] getChannels() {
+            try {
+                return (MidiChannel[]) getChannels.invoke(synth);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to query SoftSynthesizer channels", ex);
+            }
+        }
+
+        Receiver getReceiver() {
+            try {
+                return (Receiver) getReceiver.invoke(synth);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to acquire SoftSynthesizer receiver", ex);
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                close.invoke(synth);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new IllegalStateException("Failed to close SoftSynthesizer", ex);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the direct SoftSynthesizer dependency with a reflection-based facade so the module system no longer blocks compilation
- ensure the synthesizer is always closed even if stream creation fails

## Testing
- ./gradlew build *(fails: Unable to access jarfile /workspace/gmidi/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c1736cc48326afcbf14401acde7b