### PR TITLE
Improve playback visuals and offline rendering

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ application {
     mainModule = 'com.gmidi'
     mainClass  = 'com.gmidi.MainApp'
     applicationDefaultJvmArgs = prismVerboseEnabled.map { enabled ->
-        def args = ['-Dprism.allowhidpi=false']
+        def args = ['-Dprism.allowhidpi=false', '--add-exports=java.desktop/com.sun.media.sound=ALL-UNNAMED']
         if (enabled) {
             args << '-Dprism.verbose=true'
         }
@@ -49,6 +49,7 @@ application {
 
 tasks.withType(JavaExec).configureEach {
     modularity.inferModulePath = true
+    jvmArgs '--add-exports=java.desktop/com.sun.media.sound=ALL-UNNAMED'
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
## Summary
- build sustain-aware visual notes with a tick clock and schedule key holds when pre-spawning playback events
- keep key-fall bars visible until release and drive keyboard highlights via release timelines
- update the offline audio renderer to open the SoftSynth through reflection and add the required JVM export flag before muxing audio

## Testing
- `./gradlew test` *(fails: wrapper JAR missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c8d99350832691a3550d8e8a361b