### PR TITLE
Improve playback scheduling and audio export fallback

### DIFF
--- a/app/src/main/java/com/gmidi/ui/KeyboardView.java
+++ b/app/src/main/java/com/gmidi/ui/KeyboardView.java
@@ -93,6 +93,31 @@ public class KeyboardView extends Region {
         redraw();
     }
 
+    public void noteOnFallback(int midiNote) {
+        if (midiNote < 0 || midiNote >= pressed.length) {
+            return;
+        }
+        markDown(midiNote);
+        keyReleaseMicros.remove(midiNote);
+        redraw();
+    }
+
+    public void noteOffSchedule(int midiNote, long releaseMicros) {
+        if (midiNote < 0 || midiNote >= pressed.length) {
+            return;
+        }
+        if (releaseMicros <= 0L) {
+            keyReleaseMicros.remove(midiNote);
+            if (markUp(midiNote)) {
+                redraw();
+            }
+            return;
+        }
+        markDown(midiNote);
+        keyReleaseMicros.merge(midiNote, releaseMicros, Math::max);
+        redraw();
+    }
+
     public void tickMicros(long nowMicros) {
         if (keyReleaseMicros.isEmpty()) {
             return;


### PR DESCRIPTION
## Summary
- add live key tracking and sustain-aware scheduling in the replayer to prevent premature releases and honour CC64 tails
- extend the keyboard view and session controller plumbing so fallback note-ons stay held until real release information arrives
- refactor offline audio rendering to use the SoftSynth via reflection with a fluidsynth CLI fallback and surface clear export warnings

## Testing
- `./gradlew -p app build` *(fails: gradle-wrapper.jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9cfc337b08326bc91241ef6cc4e6b